### PR TITLE
Handle missing language strategies and expand tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 /.idea
-/src/test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # DepSpider
 This framework is built with Java and is designed to scan and analyze page-level component dependencies within React-based front-end projects.
-
 这个框架由 Java 构建，旨在扫描和分析基于 React 的前端项目中的页面级组件依赖关系。
 ---
 

--- a/src/main/java/org/wzl/depspider/react/project/ReactProjectOperator.java
+++ b/src/main/java/org/wzl/depspider/react/project/ReactProjectOperator.java
@@ -96,7 +96,7 @@ public class ReactProjectOperator implements IReactProjectOperator {
                 this.srcFolderChildren.add(file);
             }
         }
-        log.info("JSXProjectOperator initialized with project path: {}", projectPath);
+        log.info("ReactProjectOperator initialized with project path: {}", projectPath);
         initProject();
     }
 
@@ -114,11 +114,14 @@ public class ReactProjectOperator implements IReactProjectOperator {
                 languageStrategies.add(languageStrategy1);
             }
         }
-        if (languageStrategies.size() > 1) {
+        if (languageStrategies.isEmpty()) {
+            throw new IllegalStateException("No language strategy found");
+        } else if (languageStrategies.size() > 1) {
             languageStrategy = new CompositeLanguageStrategy(languageStrategies);
         } else {
             languageStrategy = languageStrategies.get(0);
         }
+
     }
 
     private void setScanPath() {
@@ -261,8 +264,9 @@ public class ReactProjectOperator implements IReactProjectOperator {
     }
 
     /**
-     * 获取所有的代码文件；
-     * @return  代码文件
+     * 获取所有的代码文件
+     * @param folder 当前处理的文件或文件夹
+     * @param allCodeFile 收集代码文件的列表
      */
     private void getAllCodeFile(File folder, List<File> allCodeFile) {
         if (Objects.isNull(folder)) {

--- a/src/test/java/org/wzl/depspider/utils/FileUtilTest.java
+++ b/src/test/java/org/wzl/depspider/utils/FileUtilTest.java
@@ -1,0 +1,36 @@
+package org.wzl.depspider.utils;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+public class FileUtilTest {
+
+    @Test
+    public void resolvePathFindsNestedDirectory() throws IOException {
+        File root = Files.createTempDirectory("root").toFile();
+        File child = new File(root, "a");
+        File nested = new File(child, "b");
+        assertTrue(nested.mkdirs());
+        File resolved = FileUtil.resolvePath(root, Arrays.asList("a", "b"));
+        assertTrue(resolved.isDirectory());
+        assertEquals(nested.getAbsolutePath(), resolved.getAbsolutePath());
+    }
+
+    @Test
+    public void validateFileThrowsOnWrongSuffix() throws IOException {
+        File tempFile = File.createTempFile("test", ".txt");
+        tempFile.deleteOnExit();
+        try {
+            FileUtil.validateFile(tempFile.getAbsolutePath(), ".jsx");
+            fail("Expected RuntimeException");
+        } catch (RuntimeException expected) {
+            // expected exception
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Correct project initialization log message and allow tests
- Guard against missing language strategies and update code comments
- Add FileUtil tests for path resolution and suffix validation

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: central-publishing-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c6720cf88330940510b021a9ebca