### PR TITLE
feat: support array initializer parsing

### DIFF
--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/JSXNodeVisitor.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/JSXNodeVisitor.java
@@ -1,13 +1,16 @@
 package org.wzl.depspider.ast.jsx.parser.node;
 
 import org.wzl.depspider.ast.core.node.ASTVisitor;
+import org.wzl.depspider.ast.jsx.parser.node.definition.ArrowFunctionExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ArrayExpression;
+import org.wzl.depspider.ast.jsx.parser.node.definition.CallExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.MemberExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectProperty;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ImportDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.VariableDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.literal.NumericLiteral;
+import org.wzl.depspider.ast.jsx.parser.node.definition.ImportExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.specifier.Specifier;
 
 /**
@@ -37,4 +40,10 @@ public interface JSXNodeVisitor<T> extends ASTVisitor<T> {
     T visit(MemberExpression memberExpression);
 
     T visit(ArrayExpression arrayExpression);
+
+    T visit(CallExpression callExpression);
+
+    T visit(ArrowFunctionExpression arrowFunctionExpression);
+
+    T visit(ImportExpression importExpression);
 }

--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/JSXNodeVisitor.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/JSXNodeVisitor.java
@@ -7,6 +7,7 @@ import org.wzl.depspider.ast.jsx.parser.node.definition.CallExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.MemberExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectProperty;
+import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ExportDefaultDeclaration;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ImportDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.VariableDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.literal.NumericLiteral;
@@ -24,6 +25,8 @@ public interface JSXNodeVisitor<T> extends ASTVisitor<T> {
     T visit(FileNode fileNode);
 
     T visit(ImportDeclarationNode importDeclarationNode);
+
+    T visit(ExportDefaultDeclaration exportDefaultDeclaration);
 
     T visit(Specifier specifier);
 

--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/JSXNodeVisitorImpl.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/JSXNodeVisitorImpl.java
@@ -9,6 +9,7 @@ import org.wzl.depspider.ast.jsx.parser.node.definition.Node;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectProperty;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ImportExpression;
+import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ExportDefaultDeclaration;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ImportDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.VariableDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.literal.NumericLiteral;
@@ -33,6 +34,14 @@ public class JSXNodeVisitorImpl<T> implements JSXNodeVisitor<T> {
     public T visit(ImportDeclarationNode importDeclarationNode) {
         for (Node node : importDeclarationNode.getSpecifiers()) {
             node.accept(this);
+        }
+        return null;
+    }
+
+    @Override
+    public T visit(ExportDefaultDeclaration exportDefaultDeclaration) {
+        if (exportDefaultDeclaration.getDeclaration() != null) {
+            exportDefaultDeclaration.getDeclaration().accept(this);
         }
         return null;
     }

--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/JSXNodeVisitorImpl.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/JSXNodeVisitorImpl.java
@@ -1,11 +1,14 @@
 package org.wzl.depspider.ast.jsx.parser.node;
 
 import lombok.extern.slf4j.Slf4j;
+import org.wzl.depspider.ast.jsx.parser.node.definition.ArrowFunctionExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ArrayExpression;
+import org.wzl.depspider.ast.jsx.parser.node.definition.CallExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.MemberExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.Node;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectProperty;
+import org.wzl.depspider.ast.jsx.parser.node.definition.ImportExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ImportDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.VariableDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.literal.NumericLiteral;
@@ -75,6 +78,21 @@ public class JSXNodeVisitorImpl<T> implements JSXNodeVisitor<T> {
 
     @Override
     public T visit(ArrayExpression arrayExpression) {
+        return null;
+    }
+
+    @Override
+    public T visit(CallExpression callExpression) {
+        return null;
+    }
+
+    @Override
+    public T visit(ArrowFunctionExpression arrowFunctionExpression) {
+        return null;
+    }
+
+    @Override
+    public T visit(ImportExpression importExpression) {
         return null;
     }
 }

--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/NodeType.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/NodeType.java
@@ -12,6 +12,7 @@ import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectProperty;
 import org.wzl.depspider.ast.jsx.parser.node.definition.literal.NumericLiteral;
 import org.wzl.depspider.ast.jsx.parser.node.definition.literal.StringLiteral;
+import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ExportDefaultDeclaration;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ImportDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.VariableDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.VariableDeclarator;
@@ -25,6 +26,7 @@ public enum NodeType {
     PROGRAM("Program", ProgramNode.class),
 
     IMPORT_DECLARATION("ImportDeclaration", ImportDeclarationNode.class),
+    EXPORT_DEFAULT_DECLARATION("ExportDefaultDeclaration", ExportDefaultDeclaration.class),
     VARIABLE_DECLARATION("VariableDeclaration", VariableDeclarationNode.class),
 
     VARIABLE_DECLARATOR("VariableDeclarator", VariableDeclarator.class),

--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/NodeType.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/NodeType.java
@@ -2,8 +2,11 @@ package org.wzl.depspider.ast.jsx.parser.node;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.wzl.depspider.ast.jsx.parser.node.definition.ArrowFunctionExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ArrayExpression;
+import org.wzl.depspider.ast.jsx.parser.node.definition.CallExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.Identifier;
+import org.wzl.depspider.ast.jsx.parser.node.definition.ImportExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.MemberExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectProperty;
@@ -30,6 +33,9 @@ public enum NodeType {
 
     OBJECT_EXPRESSION("ObjectExpression", ObjectExpression.class),
     ARRAY_EXPRESSION("ArrayExpression", ArrayExpression.class),
+    CALL_EXPRESSION("CallExpression", CallExpression.class),
+    ARROW_FUNCTION_EXPRESSION("ArrowFunctionExpression", ArrowFunctionExpression.class),
+    IMPORT_EXPRESSION("Import", ImportExpression.class),
 
     NUMERICL_LITERAL("NumericLiteral", NumericLiteral.class),
 

--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/definition/ArrowFunctionExpression.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/definition/ArrowFunctionExpression.java
@@ -1,0 +1,33 @@
+package org.wzl.depspider.ast.jsx.parser.node.definition;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.wzl.depspider.ast.jsx.parser.node.JSXNodeVisitor;
+import org.wzl.depspider.ast.jsx.parser.node.NodeType;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ArrowFunctionExpression extends Expression {
+
+    private Identifier id;
+
+    private List<Node> params;
+
+    private Node body;
+
+    private boolean generator;
+
+    private boolean async;
+
+    public ArrowFunctionExpression(int start, int end, Loc loc) {
+        super(NodeType.ARROW_FUNCTION_EXPRESSION, start, end, loc);
+    }
+
+    @Override
+    public <T> T accept(JSXNodeVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+

--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/definition/CallExpression.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/definition/CallExpression.java
@@ -1,0 +1,27 @@
+package org.wzl.depspider.ast.jsx.parser.node.definition;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.wzl.depspider.ast.jsx.parser.node.JSXNodeVisitor;
+import org.wzl.depspider.ast.jsx.parser.node.NodeType;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class CallExpression extends Expression {
+
+    private Expression callee;
+
+    private List<Expression> arguments;
+
+    public CallExpression(int start, int end, Loc loc) {
+        super(NodeType.CALL_EXPRESSION, start, end, loc);
+    }
+
+    @Override
+    public <T> T accept(JSXNodeVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+

--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/definition/ImportExpression.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/definition/ImportExpression.java
@@ -1,0 +1,17 @@
+package org.wzl.depspider.ast.jsx.parser.node.definition;
+
+import org.wzl.depspider.ast.jsx.parser.node.JSXNodeVisitor;
+import org.wzl.depspider.ast.jsx.parser.node.NodeType;
+
+public class ImportExpression extends Expression {
+
+    public ImportExpression(int start, int end, Loc loc) {
+        super(NodeType.IMPORT_EXPRESSION, start, end, loc);
+    }
+
+    @Override
+    public <T> T accept(JSXNodeVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}
+

--- a/src/main/java/org/wzl/depspider/ast/jsx/parser/node/definition/declaration/ExportDefaultDeclaration.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/parser/node/definition/declaration/ExportDefaultDeclaration.java
@@ -1,0 +1,26 @@
+package org.wzl.depspider.ast.jsx.parser.node.definition.declaration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.wzl.depspider.ast.jsx.parser.node.JSXNodeVisitor;
+import org.wzl.depspider.ast.jsx.parser.node.NodeType;
+import org.wzl.depspider.ast.jsx.parser.node.definition.Loc;
+import org.wzl.depspider.ast.jsx.parser.node.definition.Node;
+
+@Getter
+@Setter
+public class ExportDefaultDeclaration extends Node {
+
+    private String exportKind;
+
+    private Node declaration;
+
+    public ExportDefaultDeclaration(int start, int end, Loc loc) {
+        super(NodeType.EXPORT_DEFAULT_DECLARATION, start, end, loc);
+    }
+
+    @Override
+    public <T> T accept(JSXNodeVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/src/main/java/org/wzl/depspider/ast/jsx/tokenizer/JSXTokenizer.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/tokenizer/JSXTokenizer.java
@@ -193,7 +193,7 @@ public class JSXTokenizer implements Tokenizer {
             } else if (c == '[') {
                 tokens.add(
                         new JSXToken(
-                                JSXToken.Type.JSX_TAG_START,
+                                JSXToken.Type.LEFT_BRACKET,
                                 advance() + "",
                                 getPos(),
                                 getPos(),
@@ -204,7 +204,7 @@ public class JSXTokenizer implements Tokenizer {
             } else if (c == ']') {
                 tokens.add(
                         new JSXToken(
-                                JSXToken.Type.JSX_TAG_END,
+                                JSXToken.Type.RIGHT_BRACKET,
                                 advance() + "",
                                 getPos(),
                                 getPos(),


### PR DESCRIPTION
## Summary
- add array expression parsing support so array initializers produce proper AST
- teach the tokenizer to emit dedicated bracket tokens and update expression skipping to track bracket depth

## Testing
- `mvn -q -DskipTests compile` *(fails: unable to resolve org.sonatype.central:central-publishing-maven-plugin:0.7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9e52d0288330beb39c8de3689468