### PR TITLE
Refactor JSXObjectVisitor to expose ObjectRecord class

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,31 @@ List<ProjectFileRelation> relations = reactProjectOperator.jsxFileRelation();
   }
 ]
 ```
+
+#### 2、使用 `JSXObjectVisitor` 获取文件中的对象表达式
+
+`JSXObjectVisitor` 可以帮助你遍历单个 JSX/TSX 文件并收集其中出现的 `ObjectExpression` 节点，便于后续进行分析或转换。最简单的使用方式如下：
+
+```java
+String indexPath = "/path/to/your/file.jsx";
+JSXParse jsxParse = new JSXParse(indexPath);
+FileNode fileNode = jsxParse.parse();
+
+JSXObjectVisitor visitor = new JSXObjectVisitor();
+visitor.visit(fileNode);
+
+// 输出采集到的对象表达式及其上下文路径
+// ObjectRecord 位于 org.wzl.depspider.ast.jsx.visitor 包中
+for (ObjectRecord record : visitor.getObjectRecords()) {
+    System.out.println(record.getPath() + " => " + record.getExpression());
+}
+```
+
+如果你想直接运行一个示例，可以执行仓库中的 `JSXObjectVisitorExample`：
+
+```bash
+mvn -DskipTests=true -q compile
+java -cp target/classes org.wzl.depspider.example.JSXObjectVisitorExample /path/to/your/file.jsx
+```
+
+示例程序会打印出文件中所有的对象表达式及其对应的路径，便于快速验证访问结果。

--- a/src/main/java/org/wzl/depspider/ast/jsx/visitor/JSXObjectVisitor.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/visitor/JSXObjectVisitor.java
@@ -5,87 +5,327 @@ import org.wzl.depspider.ast.jsx.parser.node.ProgramNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ArrayExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ArrowFunctionExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.CallExpression;
+import org.wzl.depspider.ast.jsx.parser.node.definition.Expression;
+import org.wzl.depspider.ast.jsx.parser.node.definition.Identifier;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ImportExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.MemberExpression;
+import org.wzl.depspider.ast.jsx.parser.node.definition.Node;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectExpression;
 import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectProperty;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ExportDefaultDeclaration;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.ImportDeclarationNode;
 import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.VariableDeclarationNode;
+import org.wzl.depspider.ast.jsx.parser.node.definition.declaration.VariableDeclarator;
 import org.wzl.depspider.ast.jsx.parser.node.definition.literal.NumericLiteral;
+import org.wzl.depspider.ast.jsx.parser.node.definition.literal.StringLiteral;
 import org.wzl.depspider.ast.jsx.parser.node.definition.specifier.Specifier;
 
-public class JSXObjectVisitor implements JSXNodeVisitor<Void> {
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Visitor 用于搜集 JSX 文件中出现的对象表达式。
+ */
+public class JSXObjectVisitor implements JSXNodeVisitor<ObjectRecord> {
+
+    private final List<ObjectRecord> objectRecords = new ArrayList<>();
+    private final Set<ObjectExpression> visitedExpressions =
+            Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Deque<String> nameStack = new ArrayDeque<>();
+
+    public List<ObjectRecord> getObjectRecords() {
+        return Collections.unmodifiableList(objectRecords);
+    }
+
+    public List<ObjectExpression> getObjectExpressions() {
+        List<ObjectExpression> expressions = new ArrayList<>(objectRecords.size());
+        for (ObjectRecord record : objectRecords) {
+            expressions.add(record.getExpression());
+        }
+        return Collections.unmodifiableList(expressions);
+    }
 
     @Override
-    public Void visit(FileNode fileNode) {
-        fileNode.accept(this);
+    public ObjectRecord visit(FileNode fileNode) {
+        if (fileNode == null) {
+            return null;
+        }
+        return visitNode(fileNode.getProgram());
+    }
+
+    @Override
+    public ObjectRecord visit(ImportDeclarationNode importDeclarationNode) {
+        if (importDeclarationNode == null) {
+            return null;
+        }
+        if (importDeclarationNode.getSpecifiers() != null) {
+            for (Specifier specifier : importDeclarationNode.getSpecifiers()) {
+                visit(specifier);
+            }
+        }
         return null;
     }
 
     @Override
-    public Void visit(ImportDeclarationNode importDeclarationNode) {
+    public ObjectRecord visit(ExportDefaultDeclaration exportDefaultDeclaration) {
+        if (exportDefaultDeclaration == null) {
+            return null;
+        }
+        Node declaration = exportDefaultDeclaration.getDeclaration();
+        if (declaration != null) {
+            boolean pushed = pushName("default");
+            try {
+                visitNode(declaration);
+            } finally {
+                popName(pushed);
+            }
+        }
         return null;
     }
 
     @Override
-    public Void visit(ExportDefaultDeclaration exportDefaultDeclaration) {
+    public ObjectRecord visit(Specifier specifier) {
         return null;
     }
 
     @Override
-    public Void visit(Specifier specifier) {
+    public ObjectRecord visit(ProgramNode programNode) {
+        if (programNode == null || programNode.getBody() == null) {
+            return null;
+        }
+        for (Node child : programNode.getBody()) {
+            visitNode(child);
+        }
         return null;
     }
 
     @Override
-    public Void visit(ProgramNode programNode) {
-        programNode.accept(this);
+    public ObjectRecord visit(VariableDeclarationNode variableDeclarationNode) {
+        if (variableDeclarationNode == null || variableDeclarationNode.getDeclarations() == null) {
+            return null;
+        }
+        for (VariableDeclarator declarator : variableDeclarationNode.getDeclarations()) {
+            if (declarator == null) {
+                continue;
+            }
+            Identifier identifier = declarator.getId();
+            String name = identifier != null ? identifier.getName() : null;
+            Node init = declarator.getInit();
+            boolean pushed = pushName(name);
+            try {
+                visitNode(init);
+            } finally {
+                popName(pushed);
+            }
+        }
         return null;
     }
 
     @Override
-    public Void visit(VariableDeclarationNode variableDeclarationNode) {
+    public ObjectRecord visit(ObjectExpression objectExpression) {
+        if (objectExpression == null || !visitedExpressions.add(objectExpression)) {
+            return null;
+        }
+        ObjectRecord record = new ObjectRecord(currentPath(), objectExpression);
+        objectRecords.add(record);
+        if (objectExpression.getProperties() != null) {
+            for (ObjectProperty property : objectExpression.getProperties()) {
+                visit(property);
+            }
+        }
+        return record;
+    }
+
+    @Override
+    public ObjectRecord visit(ObjectProperty objectProperty) {
+        if (objectProperty == null) {
+            return null;
+        }
+        String propertyName = resolvePropertyName(objectProperty.getKey(), objectProperty.isComputed());
+        Node value = objectProperty.getValue();
+        boolean pushed = pushName(propertyName);
+        try {
+            visitNode(value);
+        } finally {
+            popName(pushed);
+        }
         return null;
     }
 
     @Override
-    public Void visit(ObjectExpression objectExpression) {
+    public ObjectRecord visit(NumericLiteral numericLiteral) {
         return null;
     }
 
     @Override
-    public Void visit(ObjectProperty objectProperty) {
+    public ObjectRecord visit(MemberExpression memberExpression) {
+        if (memberExpression == null) {
+            return null;
+        }
+        visitNode(memberExpression.getObject());
         return null;
     }
 
     @Override
-    public Void visit(NumericLiteral numericLiteral) {
+    public ObjectRecord visit(ArrayExpression arrayExpression) {
+        if (arrayExpression == null || arrayExpression.getElements() == null) {
+            return null;
+        }
+        for (Expression element : arrayExpression.getElements()) {
+            visitNode(element);
+        }
         return null;
     }
 
     @Override
-    public Void visit(MemberExpression memberExpression) {
+    public ObjectRecord visit(CallExpression callExpression) {
+        if (callExpression == null) {
+            return null;
+        }
+        visitNode(callExpression.getCallee());
+        if (callExpression.getArguments() != null) {
+            for (Expression argument : callExpression.getArguments()) {
+                visitNode(argument);
+            }
+        }
         return null;
     }
 
     @Override
-    public Void visit(ArrayExpression arrayExpression) {
+    public ObjectRecord visit(ArrowFunctionExpression arrowFunctionExpression) {
+        if (arrowFunctionExpression == null) {
+            return null;
+        }
+        if (arrowFunctionExpression.getParams() != null) {
+            for (Node param : arrowFunctionExpression.getParams()) {
+                visitNode(param);
+            }
+        }
+        visitNode(arrowFunctionExpression.getBody());
         return null;
     }
 
     @Override
-    public Void visit(CallExpression callExpression) {
+    public ObjectRecord visit(ImportExpression importExpression) {
         return null;
     }
 
-    @Override
-    public Void visit(ArrowFunctionExpression arrowFunctionExpression) {
+    private ObjectRecord visitNode(Node node) {
+        if (node == null) {
+            return null;
+        }
+        if (node instanceof FileNode) {
+            return visit((FileNode) node);
+        }
+        if (node instanceof ProgramNode) {
+            return visit((ProgramNode) node);
+        }
+        if (node instanceof ImportDeclarationNode) {
+            return visit((ImportDeclarationNode) node);
+        }
+        if (node instanceof ExportDefaultDeclaration) {
+            return visit((ExportDefaultDeclaration) node);
+        }
+        if (node instanceof VariableDeclarationNode) {
+            return visit((VariableDeclarationNode) node);
+        }
+        if (node instanceof ObjectExpression) {
+            return visit((ObjectExpression) node);
+        }
+        if (node instanceof ObjectProperty) {
+            return visit((ObjectProperty) node);
+        }
+        if (node instanceof ArrayExpression) {
+            return visit((ArrayExpression) node);
+        }
+        if (node instanceof CallExpression) {
+            return visit((CallExpression) node);
+        }
+        if (node instanceof ArrowFunctionExpression) {
+            return visit((ArrowFunctionExpression) node);
+        }
+        if (node instanceof MemberExpression) {
+            return visit((MemberExpression) node);
+        }
+        if (node instanceof ImportExpression) {
+            return visit((ImportExpression) node);
+        }
+        if (node instanceof NumericLiteral) {
+            return visit((NumericLiteral) node);
+        }
         return null;
     }
 
-    @Override
-    public Void visit(ImportExpression importExpression) {
+    private boolean pushName(String name) {
+        if (name == null) {
+            return false;
+        }
+        String trimmed = name.trim();
+        if (trimmed.isEmpty()) {
+            return false;
+        }
+        nameStack.addLast(trimmed);
+        return true;
+    }
+
+    private void popName(boolean pushed) {
+        if (pushed && !nameStack.isEmpty()) {
+            nameStack.removeLast();
+        }
+    }
+
+    private String currentPath() {
+        if (nameStack.isEmpty()) {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder();
+        Iterator<String> iterator = nameStack.iterator();
+        while (iterator.hasNext()) {
+            String part = iterator.next();
+            if (part == null || part.isEmpty()) {
+                continue;
+            }
+            if (builder.length() > 0) {
+                builder.append('.');
+            }
+            builder.append(part);
+        }
+        return builder.length() == 0 ? null : builder.toString();
+    }
+
+    private String resolvePropertyName(Node key, boolean computed) {
+        if (computed || key == null) {
+            return null;
+        }
+        if (key instanceof Identifier) {
+            return ((Identifier) key).getName();
+        }
+        if (key instanceof StringLiteral) {
+            String value = ((StringLiteral) key).getValue();
+            return stripQuotes(value);
+        }
         return null;
     }
+
+    private String stripQuotes(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() >= 2) {
+            char first = trimmed.charAt(0);
+            char last = trimmed.charAt(trimmed.length() - 1);
+            if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
+                return trimmed.substring(1, trimmed.length() - 1);
+            }
+        }
+        return trimmed;
+    }
+
 }

--- a/src/main/java/org/wzl/depspider/ast/jsx/visitor/ObjectRecord.java
+++ b/src/main/java/org/wzl/depspider/ast/jsx/visitor/ObjectRecord.java
@@ -1,0 +1,30 @@
+package org.wzl.depspider.ast.jsx.visitor;
+
+import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectExpression;
+
+/**
+ * 记录遍历过程中发现的对象表达式。
+ */
+public final class ObjectRecord {
+    private final String path;
+    private final ObjectExpression expression;
+
+    public ObjectRecord(String path, ObjectExpression expression) {
+        this.path = path;
+        this.expression = expression;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public ObjectExpression getExpression() {
+        return expression;
+    }
+
+    @Override
+    public String toString() {
+        String prefix = (path == null || path.isEmpty()) ? "<anonymous>" : path;
+        return prefix + " -> ObjectExpression";
+    }
+}

--- a/src/main/java/org/wzl/depspider/example/JSXObjectVisitorExample.java
+++ b/src/main/java/org/wzl/depspider/example/JSXObjectVisitorExample.java
@@ -1,0 +1,36 @@
+package org.wzl.depspider.example;
+
+import org.wzl.depspider.ast.jsx.parser.JSXParse;
+import org.wzl.depspider.ast.jsx.parser.node.FileNode;
+import org.wzl.depspider.ast.jsx.parser.node.definition.ObjectExpression;
+import org.wzl.depspider.ast.jsx.visitor.JSXObjectVisitor;
+import org.wzl.depspider.ast.jsx.visitor.ObjectRecord;
+
+public final class JSXObjectVisitorExample {
+
+    private JSXObjectVisitorExample() {
+    }
+
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            System.err.println("Usage: java " + JSXObjectVisitorExample.class.getName() + " <path-to-jsx-file>");
+            System.exit(1);
+        }
+
+        String filePath = args[0];
+        JSXParse parser = new JSXParse(filePath);
+        FileNode fileNode = parser.parse();
+
+        JSXObjectVisitor visitor = new JSXObjectVisitor();
+        visitor.visit(fileNode);
+
+        System.out.println("Discovered object expressions:");
+        for (ObjectRecord record : visitor.getObjectRecords()) {
+            ObjectExpression expression = record.getExpression();
+            String path = record.getPath();
+            int propertyCount = expression.getProperties() == null ? 0 : expression.getProperties().size();
+            System.out.println("- path=" + (path == null ? "<unknown>" : path)
+                    + ", properties=" + propertyCount);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract ObjectRecord into its own class for reuse outside JSXObjectVisitor
- update JSXObjectVisitor to implement JSXNodeVisitor<ObjectRecord> and return collected records while traversing
- adjust example and README documentation to use the standalone ObjectRecord type

## Testing
- `mvn -q -DskipTests compile` *(fails: Unable to resolve org.sonatype.central:central-publishing-maven-plugin:0.7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e9bc9fd5f08330b0c18125927fc807